### PR TITLE
fix: removed extra push notification text shown on screen

### DIFF
--- a/components/FeaturesUpdate.js
+++ b/components/FeaturesUpdate.js
@@ -64,7 +64,6 @@ const FeaturesUpdate = ({navigation}) => {
           {key: 'Identify user'},
           {key: 'Clear user identity'},
           {key: 'Track event'},
-          {key: 'Push Notification'},
           {key: 'Device Attributes'},
           {key: 'Profile Attributes'},
           {key: 'Push Notifications'}


### PR DESCRIPTION
The first screen shows text `push notification` multiple times in the list of features to test. This PR is a UI fix to show Push Notification just once to the user