### PR TITLE
fix: set up config during initialisation

### DIFF
--- a/components/FeaturesUpdate.js
+++ b/components/FeaturesUpdate.js
@@ -2,22 +2,26 @@ import React, {useEffect} from "react";
 import { StyleSheet, Text, FlatList, View, Image, Button, ImageBackground, Linking} from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import {SubHeaderText} from './common/Text'
-import { CustomerIO, CustomerioConfig, CioLogLevel } from "customerio-reactnative";
+import { CustomerIO, CustomerioConfig, CioLogLevel, Region } from "customerio-reactnative";
 import Env from "../env";
 
 const FeaturesUpdate = ({navigation}) => {
 
   useEffect(() => {
 
-    // MARK:- INITIALIZE PACKAGE
-    CustomerIO.initialize(Env.siteId, Env.apiKey)
-
-    // MARK:- UPDATE CONFIGURATIONS
-    // Start
+    // MARK:- INITIALIZE PACKAGE WITH CONFIG
     const data = new CustomerioConfig()
     data.logLevel = CioLogLevel.debug
     data.autoTrackDeviceAttributes = true
-    CustomerIO.config(data)
+    CustomerIO.initialize(Env.siteId, Env.apiKey, Region.US, data) 
+
+
+    // MARK:- UPDATE CONFIGURATIONS
+    // Start
+    // const data = new CustomerioConfig()
+    // data.logLevel = CioLogLevel.debug
+    // data.autoTrackDeviceAttributes = true
+    // CustomerIO.config(data)
     // End
 
   }, [])

--- a/components/FeaturesUpdate.js
+++ b/components/FeaturesUpdate.js
@@ -10,20 +10,12 @@ const FeaturesUpdate = ({navigation}) => {
   useEffect(() => {
 
     // MARK:- INITIALIZE PACKAGE WITH CONFIG
+    // MARK:- UPDATE CONFIGURATIONS
+
     const data = new CustomerioConfig()
     data.logLevel = CioLogLevel.debug
     data.autoTrackDeviceAttributes = true
     CustomerIO.initialize(Env.siteId, Env.apiKey, Region.US, data) 
-
-
-    // MARK:- UPDATE CONFIGURATIONS
-    // Start
-    // const data = new CustomerioConfig()
-    // data.logLevel = CioLogLevel.debug
-    // data.autoTrackDeviceAttributes = true
-    // CustomerIO.config(data)
-    // End
-
   }, [])
   
   // Renderers


### PR DESCRIPTION
closes https://github.com/customerio/issues/issues/7791

Related to PR https://github.com/customerio/customerio-reactnative/pull/15

Since the app refers the package on the npm but the updates related to config are not pushed yet so running this app with this PR might result into a crash. 

Adding label `Do not Merge` until the config update is pushed to the npm.