### PR TITLE
feat: show username after user identification

### DIFF
--- a/components/FeaturesTrial.js
+++ b/components/FeaturesTrial.js
@@ -8,13 +8,15 @@ import IdentifyUser from "./IdentifyUser";
 const FeaturesTrial = () => {
 
     const [isUserIdentified, setisUserIdentified] = useState(false)
+    const [amiUserName, setAmiUserName] = useState("Ami")
 
     useEffect(() => {
       
   
     }, [])
     
-    const UserIdentified = () => {
+    const UserIdentified = (amiName) => {
+        setAmiUserName(amiName)
         setisUserIdentified(true)
     }
 
@@ -23,18 +25,19 @@ const FeaturesTrial = () => {
     }
 
     const info = isUserIdentified ? "Awesome ! Your playground is ready now." : "First, you need to identify a user to start using the other features of the app."
+    const packageInfo = `Hey ${amiUserName} ! Package is already initialised on the app launch.`
     return (
         <ImageBackground style={styles.container} source = {require('../assets/images/cio_dots_bg.png')}>
             <View style={styles.headerArea}>
                     <Image style={styles.waveAmiImage} source={require('../assets/images/cio_hand.png')}></Image>
-                    <SubHeaderText label="Hey Ami ! Package is already initialised on the app launch."/>
+                    <SubHeaderText label={packageInfo}/>
                     <SimpleText label={info}></SimpleText>
             </View>
 
             {isUserIdentified ? 
                 <AllFeatures onClear={() => OnClear()}/>
                 :
-                <IdentifyUser onPress = {() => UserIdentified()}/>
+                <IdentifyUser onPress = {(amiName) => UserIdentified(amiName)}/>
             }
             
 

--- a/components/IdentifyUser.js
+++ b/components/IdentifyUser.js
@@ -19,7 +19,7 @@ const IdentifyUser = (props) => {
         // MARK:- IDENTIFY USER
         CustomerIO.identify(emailId, {"first_name": userName})
         
-        props.onPress()
+        props.onPress(userName)
     }
 
     return (


### PR DESCRIPTION
As a self analysis feedback - Once the user has been identified on the app, the username will be displayed on the top to show which user logged in. This is reset once the user taps back button, clears identity, or relaunches the app
![Simulator Screen Shot - iPhone 13 - 2022-08-04 at 23 27 55](https://user-images.githubusercontent.com/91549653/182936709-73998f16-8c61-4063-8fd2-465963828315.png)
