### PR TITLE
chore: updated dependency to use package from data push fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@react-native-community/push-notification-ios": "^1.10.1",
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/native-stack": "^6.6.2",
-    "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative",
+    "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#e3e609ae2fee6183050d993624bd4bd287a7ec97",
     "expo": "~42.0.1",
     "expo-splash-screen": "~0.11.2",
     "expo-status-bar": "~1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,9 +2525,9 @@ css-in-js-utils@^2.0.0:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
 
-"customerio-reactnative@git+https://github.com/customerio/customerio-reactnative":
+"customerio-reactnative@git+https://github.com/customerio/customerio-reactnative#e3e609ae2fee6183050d993624bd4bd287a7ec97":
   version "0.1.0"
-  resolved "git+https://github.com/customerio/customerio-reactnative#91978d78cb5b10c90caeb088af2fc4f2a15e952b"
+  resolved "git+https://github.com/customerio/customerio-reactnative#e3e609ae2fee6183050d993624bd4bd287a7ec97"
 
 dayjs@^1.8.15:
   version "1.11.3"


### PR DESCRIPTION
### Changes

- Updated `customerio-reactnative` package to use changes from data notification commit
- Added commit hash so that it is easier to identify changes pull up to in any build