### PR TITLE
ci: fixed manual and test branch deployments

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -23,6 +23,13 @@ jobs:
       - run: echo "LATEST_GIT_TAG=${{ fromJson(steps.get_latest_release.outputs.data).tag_name }}" >> $GITHUB_ENV      
 
       - uses: actions/checkout@v2 # checkout to be able to run CI config files below 
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11' # Robolectric requires v9, but we choose LTS: https://adoptopenjdk.net/
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
       - name: Setup environment for building and releasing app 
         uses: ./.github/actions/prepare-for-app-build
         with:
@@ -30,6 +37,7 @@ jobs:
           ENV_FILE_B64: "${{ secrets.ENV_FILE_B64 }}" # cat env.js | base64
           FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }} # cat ami_app_ci_server-google_cloud_service_account.json | base64
           MATCH_GOOGLE_CLOUD_KEYS_B64: ${{ secrets.MATCH_GOOGLE_CLOUD_KEYS_B64 }} # cat gc_keys.json | base64
+          GOOGLE_SERVICES_ANDROID_BASE64: ${{ secrets.GOOGLE_SERVICES_ANDROID_BASE64 }} # cat android/app/google-services.json | base64      
 
       # Checkout the git tag right before building since older git tags might not have the necessary files 
       # that the newer CI config asks for. Do all CI environment prep before checking out the git tag. 
@@ -39,7 +47,15 @@ jobs:
           ref: ${{ env.LATEST_GIT_TAG }}
           clean: false # to not delete the files created in environment setup step
 
-      - name: Build and re-release app 
+      - name: Build and re-release Android app
+        uses: maierj/fastlane-action@v2.0.1
+        with:
+          lane: 'android deploy_app'
+          skip-tracking: true
+        env: 
+          FIREBASE_ANDROID_APP_ID: ${{ secrets.FIREBASE_ANDROID_APP_ID }} # for firebase android app distribution 
+
+      - name: Build and re-release iOS app
         uses: maierj/fastlane-action@v2.0.1
         with:
           lane: 'ios deploy_app version:${{ env.LATEST_GIT_TAG }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,13 @@ jobs:
     name: Deploy development builds 
     steps:
     - uses: actions/checkout@v2
+    - name: Set up JDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: '11' # Robolectric requires v9, but we choose LTS: https://adoptopenjdk.net/
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v2
     - name: Setup environment for building and releasing app 
       uses: ./.github/actions/prepare-for-app-build
       with:
@@ -25,8 +32,17 @@ jobs:
         ENV_FILE_B64: "${{ secrets.ENV_FILE_B64 }}" # cat env.js | base64
         FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GOOGLE_AUTH }} # cat ami_app_ci_server-google_cloud_service_account.json | base64
         MATCH_GOOGLE_CLOUD_KEYS_B64: ${{ secrets.MATCH_GOOGLE_CLOUD_KEYS_B64 }} # cat gc_keys.json | base64                 
+        GOOGLE_SERVICES_ANDROID_BASE64: ${{ secrets.GOOGLE_SERVICES_ANDROID_BASE64 }} # cat android/app/google-services.json | base64      
 
-    - name: Deploy development build via Fastlane 
+    - name: Deploy Android development build via Fastlane 
+      uses: maierj/fastlane-action@v2.0.1
+      with:
+        lane: 'android deploy_app'
+        skip-tracking: true
+      env: 
+        FIREBASE_ANDROID_APP_ID: ${{ secrets.FIREBASE_ANDROID_APP_ID }} # for firebase android app distribution 
+
+    - name: Deploy iOS development build via Fastlane 
       uses: maierj/fastlane-action@v2.0.1
       with:
         lane: 'ios deploy_app'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,10 @@
 name: Tests
 
 on:  
-  push:
-    branches-ignore: [main, beta, alpha] # skip for deployment branches. 
-    tags-ignore: ['*']
+  # Uncomment this if build on every push is needed
+  # push:
+  #   branches-ignore: [main, beta, alpha] # skip for deployment branches. 
+  #   tags-ignore: ['*']
   pull_request:
     branches: ['*']
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,11 +15,11 @@
 
 require 'json'
 
-is_enterprise_app = false
-info_plist_file_path = "ios/SampleApp/Info.plist"
-google_service_plist_file_path = "ios/SampleApp/GoogleService-Info.plist"
-
 platform :ios do  
+
+  is_enterprise_app = false
+  info_plist_file_path = "ios/SampleApp/Info.plist"
+  google_service_plist_file_path = "ios/SampleApp/GoogleService-Info.plist"
 
   before_all do |lane, options|
     if ENV['CI'] 
@@ -226,16 +226,15 @@ class GitHub
   end 
 end 
 
-gradle_file_path = "android/app/build.gradle"
-project_dir = "android"
-
 platform :android do
 
   # example for main builds: `bundle exec fastlane android deploy_app version:1.0.0"`
   # example for develoment builds (pull request, push): `bundle exec fastlane deploy_app`
   lane :deploy_app do |values|    
 
-    new_build_number = Time.now.to_i # make the build number always unique. we do this with time. 
+    gradle_file_path = "android/app/build.gradle"
+    project_dir = "android"
+
     name_of_app = "Ami App"
     new_app_version = values[:version] # pass in new app version as parameter because we can get it from new semantic version 
     is_main_build = new_app_version != nil && new_app_version != ""
@@ -254,45 +253,39 @@ platform :android do
     else 
       UI.message("Deploying a development build of app.")
 
-      # github_context only provided for non main builds. only construct it here in this else case. 
-      github_context = JSON.parse(ENV["GITHUB_CONTEXT"]) # json string
+      github = GitHub.new(JSON.parse(ENV["GITHUB_CONTEXT"])) # context is a JSON string 
+      new_build_number = github.commit_hash
 
-      if is_pull_request(github_context) 
+      if github.is_pull_request
         UI.message("I see this is a pull request. Build metadata will include helpful PR info.")
 
-        pull_request_title = github_context["event"]["pull_request"]["title"]
-        pull_request_number = github_context["event"]["pull_request"]["number"]
-        source_branch = github_context["head_ref"]
-        destination_branch = github_context["base_ref"]
-        commit_hash = github_context["sha"][0..8]
-        
-        new_app_version = "PR.#{pull_request_number}.#{commit_hash}"
+        new_app_version = "pr.#{github.pr_number}"
 
         release_notes.append(
           "build type: pull request",
-          "title: #{pull_request_title} (#{pull_request_number})",
-          "author: #{github_context["event"]["pull_request"]["user"]["login"]}",
-          "source branch: #{source_branch}",
-          "destination branch: #{destination_branch}",
-          "commit hash: #{commit_hash}"
+          "title: #{github.pr_title} (#{github.pr_number})",
+          "author: #{github.author}",
+          "source branch: #{github.source_branch}",
+          "destination branch: #{github.destination_branch}"
         )
-      elsif is_push(github_context) 
+      elsif github.is_push
         UI.message("I see this is a git commit push. Build metadata will include helpful commit info.")
 
-        branch_name = github_context["event"]["ref"].split("/").last # getting the last part of `refs/heads/test-dump` is the branch name
-        commit_hash = github_context["event"]["head_commit"]["id"][0..8] # the sha of the commit
-
-        new_app_version = "#{branch_name}.#{commit_hash}" 
+        new_app_version = "push.#{github.commit_hash}"
 
         release_notes.append(
           "build type: push",
-          "message: #{github_context["event"]["head_commit"]["message"]}",
-          "author: #{github_context["event"]["head_commit"]["committer"]["username"]}",
-          "branch: #{branch_name}",
-          "commit hash: #{commit_hash}"
+          "message: #{github.commit_message}",
+          "author: #{github.author}",
+          "branch: #{github.branch_name}"
         )
       end 
     end 
+
+    release_notes.append(      
+      "commit hash: #{github.commit_hash}",
+      "build number: #{new_build_number}"
+    )
 
     release_notes = release_notes.join("\n")
     groups = groups.join(", ")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -254,12 +254,13 @@ platform :android do
       UI.message("Deploying a development build of app.")
 
       github = GitHub.new(JSON.parse(ENV["GITHUB_CONTEXT"])) # context is a JSON string 
-      new_build_number = github.commit_hash
+      # Not aligned with iOS as this has to integer and unique for Android
+      new_build_number = Time.now.to_i
 
       if github.is_pull_request
         UI.message("I see this is a pull request. Build metadata will include helpful PR info.")
 
-        new_app_version = "pr.#{github.pr_number}"
+        new_app_version = "pr.#{github.pr_number}.#{github.commit_hash}"
 
         release_notes.append(
           "build type: pull request",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -260,7 +260,7 @@ platform :android do
       if github.is_pull_request
         UI.message("I see this is a pull request. Build metadata will include helpful PR info.")
 
-        new_app_version = "pr.#{github.pr_number}.#{github.commit_hash}"
+        new_app_version = "pr.#{github.pr_number}"
 
         release_notes.append(
           "build type: pull request",


### PR DESCRIPTION
Closes: [29](https://github.com/customerio/amiapp-reactnative/issues/29)

### Changes

- Updated deploying builds from test branches script to support Android
- Fixed deploying builds manually for Android
- Use defined Github class for Android deployment (to align with iOS)
- Disabled builds on every push as it was creating unnecessary builds. Builds will now only be created from main branches and on PRs