### PR TITLE
feat: register device from javascript using react native package

### DIFF
--- a/components/AllFeatures.js
+++ b/components/AllFeatures.js
@@ -8,8 +8,7 @@ import ClearIdentity from './ClearIdentity';
 const AllFeatures = (props) => {
   return (
     <ScrollView style={styles.container}>
-        <TrackEvent>
-        </TrackEvent>
+        <TrackEvent/>
         <DeviceAttributes/>
         <ProfileAttributes/>
         <ClearIdentity onClear={props.onClear}/>

--- a/components/AllFeatures.js
+++ b/components/AllFeatures.js
@@ -4,11 +4,13 @@ import TrackEvent from "./TrackEvent";
 import {DeviceAttributes, ProfileAttributes} from "./Attributes";
 import { ScrollView } from 'react-native-gesture-handler';
 import ClearIdentity from './ClearIdentity';
+import RegisterDeviceToken from './RegisterDeviceToken';
 
 const AllFeatures = (props) => {
   return (
     <ScrollView style={styles.container}>
         <TrackEvent/>
+        <RegisterDeviceToken/>
         <DeviceAttributes/>
         <ProfileAttributes/>
         <ClearIdentity onClear={props.onClear}/>

--- a/components/FeaturesUpdate.js
+++ b/components/FeaturesUpdate.js
@@ -66,6 +66,7 @@ const FeaturesUpdate = ({navigation}) => {
           {key: 'Initialize package'},
           {key: 'Identify user'},
           {key: 'Clear user identity'},
+          {key: 'Register device token'},
           {key: 'Track event'},
           {key: 'Device Attributes'},
           {key: 'Profile Attributes'},

--- a/components/RegisterDeviceToken.js
+++ b/components/RegisterDeviceToken.js
@@ -1,5 +1,5 @@
 import React, {useState} from "react";
-import { StyleSheet, View } from "react-native";
+import { StyleSheet, View, Text } from "react-native";
 import FeatureButton from "./common/FeatureButton";
 import { SubHeaderText } from "./common/Text";
 import { CustomerIO } from 'customerio-reactnative';
@@ -17,7 +17,7 @@ const RegisterDeviceToken = (props) => {
         const token = generateRandomToken()
         // MARK:- REGISTER DEVICE TOKEN 
         CustomerIO.registerDeviceToken(token)
-        setDeviceToken(deviceToken)
+        setDeviceToken(token)
         alert("Device token registered")
     }
 
@@ -39,6 +39,9 @@ const RegisterDeviceToken = (props) => {
                 title ="Register token"
                 style={{marginBottom: 20}}
                 onPress = {() => registerDevice()}></FeatureButton>
+            </View>
+            <View style={styles.deviceTokenText}>
+                <Text>{deviceToken}</Text>
             </View>
         </View>
     )
@@ -64,6 +67,11 @@ const styles = StyleSheet.create({
         borderColor: '#e6e6e6',
         borderRadius: 10
       },
+      deviceTokenText:{
+        flex:1,
+        paddingLeft:25,
+        paddingRight:25
+    }
 })
 
 export default RegisterDeviceToken;

--- a/components/RegisterDeviceToken.js
+++ b/components/RegisterDeviceToken.js
@@ -1,5 +1,5 @@
 import React, {useState} from "react";
-import { StyleSheet, View, Text } from "react-native";
+import { StyleSheet, View, Text, Platform } from "react-native";
 import FeatureButton from "./common/FeatureButton";
 import { SubHeaderText } from "./common/Text";
 import { CustomerIO } from 'customerio-reactnative';
@@ -22,9 +22,13 @@ const RegisterDeviceToken = (props) => {
     }
 
     const generateRandomToken = () => {
+        let length = 163
+        if (Platform.OS == "ios"){
+            length = 64
+        }
         const char = 'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890';
         const random = Array.from(
-            {length: 50},
+            {length: 64},
             () => char[Math.floor(Math.random() * char.length)]
         );
         const randomString = random.join("");

--- a/components/RegisterDeviceToken.js
+++ b/components/RegisterDeviceToken.js
@@ -7,21 +7,19 @@ import { CustomerIO } from 'customerio-reactnative';
 
 const RegisterDeviceToken = (props) => {
 
-    const ClearUserIdentity = () => {
-        // MARK:- CLEAR USER IDENTITY
-        CustomerIO.clearIdentify()
-        
-        props.onClear()
+    const registerDevice = (forToken) => {
+        // MARK:- REGISTER DEVICE TOKEN 
+        CustomerIO.registerDeviceToken(forToken)
     }
 
     return (
         <View style={styles.container}>
-            <SubHeaderText label = "CLEAR USER IDENTITY"/>
+            <SubHeaderText label = "REGISTER DEVICE TOKEN"/>
             <View style={styles.innerContainer}>
                 <FeatureButton
-                title ="Clear user identity"
+                title ="Register token"
                 style={{marginBottom: 20}}
-                onPress = {() => ClearUserIdentity()}></FeatureButton>
+                onPress = {() => registerDevice("stubTokenjsd86782hjd897d8whdjwd")}></FeatureButton>
             </View>
         </View>
     )

--- a/components/RegisterDeviceToken.js
+++ b/components/RegisterDeviceToken.js
@@ -7,10 +7,27 @@ import { CustomerIO } from 'customerio-reactnative';
 
 const RegisterDeviceToken = (props) => {
 
-    const registerDevice = (forToken) => {
+    const registerDevice = () => {
+
+        // For the sake of testing, we are generating a random
+        // alphanumeric string and passing it as a token.
+        // Customer.io expects a valid token to send push notifications
+        // to the user.
+        const token = generateRandomToken()
+        
         // MARK:- REGISTER DEVICE TOKEN 
-        CustomerIO.registerDeviceToken(forToken)
+        CustomerIO.registerDeviceToken(token)
     }
+
+    const generateRandomToken = () => {
+        const char = 'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890';
+        const random = Array.from(
+            {length: 15},
+            () => char[Math.floor(Math.random() * char.length)]
+        );
+        const randomString = random.join("");
+        return randomString
+      }
 
     return (
         <View style={styles.container}>
@@ -19,7 +36,7 @@ const RegisterDeviceToken = (props) => {
                 <FeatureButton
                 title ="Register token"
                 style={{marginBottom: 20}}
-                onPress = {() => registerDevice("stubTokenjsd86782hjd897d8whdjwd")}></FeatureButton>
+                onPress = {() => registerDevice()}></FeatureButton>
             </View>
         </View>
     )

--- a/components/RegisterDeviceToken.js
+++ b/components/RegisterDeviceToken.js
@@ -1,0 +1,52 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import FeatureButton from "./common/FeatureButton";
+import { SubHeaderText } from "./common/Text";
+import { CustomerIO } from 'customerio-reactnative';
+
+
+const RegisterDeviceToken = (props) => {
+
+    const ClearUserIdentity = () => {
+        // MARK:- CLEAR USER IDENTITY
+        CustomerIO.clearIdentify()
+        
+        props.onClear()
+    }
+
+    return (
+        <View style={styles.container}>
+            <SubHeaderText label = "CLEAR USER IDENTITY"/>
+            <View style={styles.innerContainer}>
+                <FeatureButton
+                title ="Clear user identity"
+                style={{marginBottom: 20}}
+                onPress = {() => ClearUserIdentity()}></FeatureButton>
+            </View>
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    container : {
+        backgroundColor: 'white',
+        marginTop: 20,
+        borderRadius: 25
+    },
+    innerContainer: {
+        marginTop: 5,
+    },
+    input: {
+        height: 40,
+        marginLeft: 12,
+        marginRight: 12,
+        marginBottom: 12,
+        borderWidth: 1,
+        padding: 10,
+        backgroundColor: 'white',
+        borderColor: '#e6e6e6',
+        borderRadius: 10
+      },
+})
+
+export default RegisterDeviceToken;

--- a/components/RegisterDeviceToken.js
+++ b/components/RegisterDeviceToken.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useState} from "react";
 import { StyleSheet, View } from "react-native";
 import FeatureButton from "./common/FeatureButton";
 import { SubHeaderText } from "./common/Text";
@@ -7,6 +7,7 @@ import { CustomerIO } from 'customerio-reactnative';
 
 const RegisterDeviceToken = (props) => {
 
+    const [deviceToken, setDeviceToken] = useState('')
     const registerDevice = () => {
 
         // For the sake of testing, we are generating a random
@@ -14,15 +15,16 @@ const RegisterDeviceToken = (props) => {
         // Customer.io expects a valid token to send push notifications
         // to the user.
         const token = generateRandomToken()
-        
         // MARK:- REGISTER DEVICE TOKEN 
         CustomerIO.registerDeviceToken(token)
+        setDeviceToken(deviceToken)
+        alert("Device token registered")
     }
 
     const generateRandomToken = () => {
         const char = 'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890';
         const random = Array.from(
-            {length: 15},
+            {length: 50},
             () => char[Math.floor(Math.random() * char.length)]
         );
         const randomString = random.join("");

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.76.0)
-  - customerio-reactnative (2.0.0-alpha.1):
+  - customerio-reactnative (1.0.0):
     - CustomerIOMessagingInApp (~> 2.0.0)
     - CustomerIOTracking (~> 2.0.0)
     - React-Core
@@ -577,7 +577,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CustomerIO: 475bde679fccf3872d51d65240dc49fb208b1204
-  customerio-reactnative: 0050aea91361b9169a3a80fd8f0c69b4255f36b0
+  customerio-reactnative: d94797e94613346a3974406db6a9991b8e4887f2
   CustomerIOCommon: e767a1043b863e4b824d2b5b764f1d75a7dfc6a6
   CustomerIOMessagingInApp: 1f795a80a5c9f31c24e47d7f1fd2ee258815954f
   CustomerIOMessagingPush: e0949959ad12673b906d62061db4eca5feff4b69

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@react-native-community/push-notification-ios": "^1.10.1",
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/native-stack": "^6.6.2",
-    "customerio-reactnative": "2.0.0-alpha.1",
+    "customerio-reactnative": "https://github.com/customerio/customerio-reactnative#aman/register-device",
     "expo": "~42.0.1",
     "expo-splash-screen": "~0.11.2",
     "expo-status-bar": "~1.0.4",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@react-native-community/push-notification-ios": "^1.10.1",
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/native-stack": "^6.6.2",
-    "customerio-reactnative": "https://github.com/customerio/customerio-reactnative#aman/register-device",
+    "customerio-reactnative": "2.0.1",
     "expo": "~42.0.1",
     "expo-splash-screen": "~0.11.2",
     "expo-status-bar": "~1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,9 +2525,10 @@ css-in-js-utils@^2.0.0:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
 
-"customerio-reactnative@https://github.com/customerio/customerio-reactnative#aman/register-device":
-  version "1.0.0"
-  resolved "https://github.com/customerio/customerio-reactnative#12c516f5487417b946642bb66609badf7032fce9"
+customerio-reactnative@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/customerio-reactnative/-/customerio-reactnative-2.0.1.tgz#fe0361ca064449bad6ba2d0248ed25a8aed152f4"
+  integrity sha512-jdwYBFy7Tz0fsZTb9Fr1yK6NhypQsvdiKKobhJAjzlETyK2YXdypoZ4sRL9ExmSSiCYulSMU0zTboNBXeZQf9g==
 
 dayjs@^1.8.15:
   version "1.11.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,10 +2525,9 @@ css-in-js-utils@^2.0.0:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
 
-customerio-reactnative@2.0.0-alpha.1:
-  version "2.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/customerio-reactnative/-/customerio-reactnative-2.0.0-alpha.1.tgz#fe2bf7686e6ee6f0264e24e48eca825f907081b3"
-  integrity sha512-SJvGP+AKa2fPrze/mndRh2opygO/s8PvFnb8SYW+WeXfz2jphJuey35SrnzVSu+YGpYSZlMINzrNltS1JpXLNg==
+"customerio-reactnative@https://github.com/customerio/customerio-reactnative#aman/register-device":
+  version "1.0.0"
+  resolved "https://github.com/customerio/customerio-reactnative#12c516f5487417b946642bb66609badf7032fce9"
 
 dayjs@^1.8.15:
   version "1.11.3"


### PR DESCRIPTION
Allow users to register device from their app by calling `CustomerIO.registerDeviceToken("token") ` from their app.

### NOTE
For testing sake, this app generates random alphanumeric strings same length as of APNS device token and FCM token. Do not expect the device to receive push notifications on these "stub" device tokens.