### PR TITLE
feat: add in-app event listeners

### DIFF
--- a/components/FeaturesUpdate.js
+++ b/components/FeaturesUpdate.js
@@ -2,7 +2,7 @@ import React, {useEffect} from "react";
 import { StyleSheet, Text, FlatList, View, Image, Button, ImageBackground, Linking} from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import {SubHeaderText} from './common/Text'
-import { CustomerIO, CustomerioConfig, CioLogLevel, CustomerIOEnv } from "customerio-reactnative";
+import { CustomerIO, CustomerioConfig, CioLogLevel, CustomerIOEnv, InAppMessageEventType, InAppMessageEvent } from "customerio-reactnative";
 import Env from "../env";
 
 const FeaturesUpdate = ({navigation}) => {
@@ -25,6 +25,43 @@ const FeaturesUpdate = ({navigation}) => {
     CustomerIO.initialize(env, data) 
   }, [])
   
+  useEffect(() => {
+    CustomerIO.inAppMessaging().registerEventsListener((event) => {
+      console.log(event)
+      switch (event.eventType) {
+        case InAppMessageEventType.messageShown:
+          CustomerIO.track(
+            "in-app event",
+            { "event_name": "message shown", "delivery_id": event.deliveryId ?? "NULL", "message_id": event.messageId }
+          )
+          break;
+        case InAppMessageEventType.messageDismissed:
+          CustomerIO.track(
+            "in-app event",
+            { "event_name": "message dismissed", "delivery_id": event.deliveryId ?? "NULL", "message_id": event.messageId }
+          )
+          break;
+        case InAppMessageEventType.errorWithMessage:
+          CustomerIO.track(
+            "in-app event",
+            { "event_name": "message error", "delivery_id": event.deliveryId ?? "NULL", "message_id": event.messageId }
+          )
+          break;
+        case InAppMessageEventType.messageActionTaken:
+          CustomerIO.track(
+            "in-app event",
+            { "event_name": "message action", "delivery_id": event.deliveryId ?? "NULL", "message_id": event.messageId, "action": event.actionValue, "name": event.actionName }
+          )
+          break;
+        default:
+          CustomerIO.track(
+            "in-app event",
+            { "event_name": "unsupported event", "event": event }
+          )
+      }
+    });
+  }, [])
+
   // Renderers
     const renderSeparator = () => {  
         return (  

--- a/components/FeaturesUpdate.js
+++ b/components/FeaturesUpdate.js
@@ -16,11 +16,11 @@ const FeaturesUpdate = ({navigation}) => {
     const data = new CustomerioConfig()
     data.logLevel = CioLogLevel.debug
     data.autoTrackDeviceAttributes = true
+    data.enableInApp = true
 
     const env = new CustomerIOEnv()
     env.siteId = Env.siteId
     env.apiKey = Env.apiKey
-    env.organizationId = Env.organizationId
 
     CustomerIO.initialize(env, data) 
   }, [])

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -14,7 +14,7 @@ target 'SampleApp' do
   pod 'boost', :podspec => '../node_modules/react-native/third-party-podspecs/boost.podspec'
   # Setting up push permission handler
   pod 'Permission-Notifications', :path => "#{permissions_path}/Notifications"
-  pod 'CustomerIO/MessagingPushAPN', '~> 2.0.1'
+  pod 'CustomerIO/MessagingPushAPN', '~> 2.1.0-beta.2'
   
   # Uncomment to opt-in to using Flipper
   #
@@ -27,7 +27,7 @@ target 'SampleApp' do
 end
 
 target 'Notification Service' do
-  pod 'CustomerIO/MessagingPushAPN', '~> 2.0.1'
+  pod 'CustomerIO/MessagingPushAPN', '~> 2.1.0-beta.2'
 end
 
 # workaround for xcode14 for a react native dependency: https://github.com/expo/eas-cli/issues/1432#issuecomment-1285199900

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.76.0)
-  - customerio-reactnative (1.0.0):
+  - customerio-reactnative (2.1.0):
     - CustomerIOMessagingInApp (~> 2.1.0-beta.2)
     - CustomerIOTracking (~> 2.1.0-beta.2)
     - React-Core
@@ -587,7 +587,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CustomerIO: 12984963264bcfe4f16bb84934dbc81b85b7eccc
-  customerio-reactnative: f972ba5e4fefdb1282868d880c002947cb4bbdf0
+  customerio-reactnative: 3f6267bc684c96452c80dbf8e21669e2f2112405
   CustomerIOCommon: 26e771357e4add7bd95ba7f7754665a80f1175a0
   CustomerIOMessagingInApp: b3d4981fb1b8802ac0b64028a2493ae8dcbeac64
   CustomerIOMessagingPush: 58402854467375646496fb765e76ea55a1f40959

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
   - boost (1.76.0)
   - customerio-reactnative (1.0.0):
-    - CustomerIOMessagingInApp (~> 2.0.0)
-    - CustomerIOTracking (~> 2.0.0)
+    - CustomerIOMessagingInApp (~> 2.1.0-beta.2)
+    - CustomerIOTracking (~> 2.1.0-beta.2)
     - React-Core
-  - CustomerIO/MessagingPushAPN (2.0.1):
-    - CustomerIOMessagingPushAPN (= 2.0.1)
-  - CustomerIOCommon (2.0.1)
-  - CustomerIOMessagingInApp (2.0.1):
-    - CustomerIOTracking (= 2.0.1)
-    - Gist (~> 2.2.1)
-  - CustomerIOMessagingPush (2.0.1):
-    - CustomerIOTracking (= 2.0.1)
-  - CustomerIOMessagingPushAPN (2.0.1):
-    - CustomerIOMessagingPush (= 2.0.1)
-  - CustomerIOTracking (2.0.1):
-    - CustomerIOCommon (= 2.0.1)
+  - CustomerIO/MessagingPushAPN (2.1.0-beta.2):
+    - CustomerIOMessagingPushAPN (= 2.1.0-beta.2)
+  - CustomerIOCommon (2.1.0-beta.2)
+  - CustomerIOMessagingInApp (2.1.0-beta.2):
+    - CustomerIOTracking (= 2.1.0-beta.2)
+    - Gist (~> 3.0.4)
+  - CustomerIOMessagingPush (2.1.0-beta.2):
+    - CustomerIOTracking (= 2.1.0-beta.2)
+  - CustomerIOMessagingPushAPN (2.1.0-beta.2):
+    - CustomerIOMessagingPush (= 2.1.0-beta.2)
+  - CustomerIOTracking (2.1.0-beta.2):
+    - CustomerIOCommon (= 2.1.0-beta.2)
   - DoubleConversion (1.1.6)
   - EXApplication (3.2.0):
     - UMCore
@@ -65,7 +65,7 @@ PODS:
     - React-jsi (= 0.69.1)
     - ReactCommon/turbomodule/core (= 0.69.1)
   - fmt (6.2.1)
-  - Gist (2.2.4)
+  - Gist (3.0.4)
   - glog (0.3.5)
   - Permission-Notifications (3.6.1):
     - RNPermissions
@@ -401,7 +401,7 @@ PODS:
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - customerio-reactnative (from `../node_modules/customerio-reactnative`)
-  - CustomerIO/MessagingPushAPN (~> 2.0.1)
+  - CustomerIO/MessagingPushAPN (~> 2.1.0-beta.2)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - EXApplication (from `../node_modules/expo-application/ios`)
   - EXConstants (from `../node_modules/expo-constants/ios`)
@@ -586,13 +586,13 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
-  CustomerIO: 475bde679fccf3872d51d65240dc49fb208b1204
-  customerio-reactnative: d94797e94613346a3974406db6a9991b8e4887f2
-  CustomerIOCommon: e767a1043b863e4b824d2b5b764f1d75a7dfc6a6
-  CustomerIOMessagingInApp: 1f795a80a5c9f31c24e47d7f1fd2ee258815954f
-  CustomerIOMessagingPush: e0949959ad12673b906d62061db4eca5feff4b69
-  CustomerIOMessagingPushAPN: 80b410fbc3efe3f45c0fa40a3fcbf14b1eabe19d
-  CustomerIOTracking: c5e06490a11aca6161c34a8eb130eca87426c16b
+  CustomerIO: 12984963264bcfe4f16bb84934dbc81b85b7eccc
+  customerio-reactnative: f972ba5e4fefdb1282868d880c002947cb4bbdf0
+  CustomerIOCommon: 26e771357e4add7bd95ba7f7754665a80f1175a0
+  CustomerIOMessagingInApp: b3d4981fb1b8802ac0b64028a2493ae8dcbeac64
+  CustomerIOMessagingPush: 58402854467375646496fb765e76ea55a1f40959
+  CustomerIOMessagingPushAPN: 853e23e5beafd45119a5206841405bbe4c0c8316
+  CustomerIOTracking: fbb66324aa8a687585e29db377aa056a989e756b
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EXApplication: 9ff2a206009d6e55bca6c20b3f33d07986b51ef3
   EXConstants: 4cb52b6d8f636c767104a44bf7db3873e9c01a6f
@@ -609,7 +609,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 068141206af867f72854753423d0117c4bf53419
   FBReactNativeSpec: 546a637adc797fa436dd51d1c63c580f820de31c
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  Gist: df62edf9ce6ff2a4b6dbcf2b4f7c020d3ec260a4
+  Gist: 1d680df00ff6dbcc4fac9844b90454f30778dcbc
   glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
   Permission-Notifications: 150484ae586eb9be4e32217582a78350a9bb31c3
   RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
@@ -650,6 +650,6 @@ SPEC CHECKSUMS:
   UMTaskManagerInterface: 2be431101b73604e64fbfffcf759336f9d8fccbb
   Yoga: 7ab6e3ee4ce47d7b789d1cb520163833e515f452
 
-PODFILE CHECKSUM: 1c681df16fe1fe7346443a4365fbf4cf83e39e1e
+PODFILE CHECKSUM: 0bfe43cbbf7b34abbf12d1b245ce3a91b2c85233
 
 COCOAPODS: 1.11.3

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@react-native-community/push-notification-ios": "^1.10.1",
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/native-stack": "^6.6.2",
-    "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#d54174bd48586b35033d18c90290e927f0fee970",
+    "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#35dceb293b746845425e977df42e07959df8b60b",
     "expo": "~42.0.1",
     "expo-splash-screen": "~0.11.2",
     "expo-status-bar": "~1.0.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@react-native-community/push-notification-ios": "^1.10.1",
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/native-stack": "^6.6.2",
-    "customerio-reactnative": "2.0.1",
+    "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#1f0a26389f259efddd2de9a770c10a77a36f44bf",
     "expo": "~42.0.1",
     "expo-splash-screen": "~0.11.2",
     "expo-status-bar": "~1.0.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@react-native-community/push-notification-ios": "^1.10.1",
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/native-stack": "^6.6.2",
-    "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#35dceb293b746845425e977df42e07959df8b60b",
+    "customerio-reactnative": "2.1.0",
     "expo": "~42.0.1",
     "expo-splash-screen": "~0.11.2",
     "expo-status-bar": "~1.0.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@react-native-community/push-notification-ios": "^1.10.1",
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/native-stack": "^6.6.2",
-    "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#1f0a26389f259efddd2de9a770c10a77a36f44bf",
+    "customerio-reactnative": "git+https://github.com/customerio/customerio-reactnative#d54174bd48586b35033d18c90290e927f0fee970",
     "expo": "~42.0.1",
     "expo-splash-screen": "~0.11.2",
     "expo-status-bar": "~1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,10 +2525,9 @@ css-in-js-utils@^2.0.0:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
 
-customerio-reactnative@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/customerio-reactnative/-/customerio-reactnative-2.0.1.tgz#fe0361ca064449bad6ba2d0248ed25a8aed152f4"
-  integrity sha512-jdwYBFy7Tz0fsZTb9Fr1yK6NhypQsvdiKKobhJAjzlETyK2YXdypoZ4sRL9ExmSSiCYulSMU0zTboNBXeZQf9g==
+"customerio-reactnative@git+https://github.com/customerio/customerio-reactnative#1f0a26389f259efddd2de9a770c10a77a36f44bf":
+  version "1.0.0"
+  resolved "git+https://github.com/customerio/customerio-reactnative#1f0a26389f259efddd2de9a770c10a77a36f44bf"
 
 dayjs@^1.8.15:
   version "1.11.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,9 +2525,10 @@ css-in-js-utils@^2.0.0:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
 
-"customerio-reactnative@git+https://github.com/customerio/customerio-reactnative#35dceb293b746845425e977df42e07959df8b60b":
-  version "1.0.0"
-  resolved "git+https://github.com/customerio/customerio-reactnative#35dceb293b746845425e977df42e07959df8b60b"
+customerio-reactnative@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/customerio-reactnative/-/customerio-reactnative-2.1.0.tgz#740f9e6e937d05041ddcc1f2f47d43d1253e1ce5"
+  integrity sha512-qzgcgvizUWzpXxSiFsCAGTaLgce7l6LW8Nx8UMZUt//ldFMvLHGFFz6/dHvTXNn3mswe2VwIceyjXYHYiDDuPQ==
 
 dayjs@^1.8.15:
   version "1.11.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,9 +2525,9 @@ css-in-js-utils@^2.0.0:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
 
-"customerio-reactnative@git+https://github.com/customerio/customerio-reactnative#d54174bd48586b35033d18c90290e927f0fee970":
+"customerio-reactnative@git+https://github.com/customerio/customerio-reactnative#35dceb293b746845425e977df42e07959df8b60b":
   version "1.0.0"
-  resolved "git+https://github.com/customerio/customerio-reactnative#d54174bd48586b35033d18c90290e927f0fee970"
+  resolved "git+https://github.com/customerio/customerio-reactnative#35dceb293b746845425e977df42e07959df8b60b"
 
 dayjs@^1.8.15:
   version "1.11.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,9 +2525,9 @@ css-in-js-utils@^2.0.0:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
 
-"customerio-reactnative@git+https://github.com/customerio/customerio-reactnative#1f0a26389f259efddd2de9a770c10a77a36f44bf":
+"customerio-reactnative@git+https://github.com/customerio/customerio-reactnative#d54174bd48586b35033d18c90290e927f0fee970":
   version "1.0.0"
-  resolved "git+https://github.com/customerio/customerio-reactnative#1f0a26389f259efddd2de9a770c10a77a36f44bf"
+  resolved "git+https://github.com/customerio/customerio-reactnative#d54174bd48586b35033d18c90290e927f0fee970"
 
 dayjs@^1.8.15:
   version "1.11.3"


### PR DESCRIPTION
Feature PR: https://github.com/customerio/customerio-reactnative/pull/89, https://github.com/customerio/customerio-reactnative/pull/71

### QA Instructions:

- Install `PR.43` builds for testing
- Whenever an event is triggered from in-app message event listener, you'll see tracking event named `"in-app event"` on fly. The attributes for each event will appear as follows:
  -  message shown -> `{ event_name: "message shown", delivery_id: "deliveryID", message_id: "messageId" }`
  -  message dismissed -> `{ event_name: "message dismissed", delivery_id: "deliveryID", message_id: "messageId" }`
  -  message error -> `{ event_name: "message error", delivery_id: "deliveryID", message_id: "messageId" }`
  -  message action taken -> `{ event_name: "message action", delivery_id: "deliveryID", message_id: "messageId", action: "actionValue", name: "actionName" }`
  - incorrect event (this should never happen) -> `{ event_name: "unsupported event", event: event }`
- In addition to tracking, console logs are also available on every event. But they may only be available on browser console using [react native developer tools](https://reactnative.dev/docs/debugging#chrome-developer-tools)