### PR TITLE
fix: setting delegate for UNUserNotificationCenter

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -37,6 +37,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     self.window?.rootViewController = rootViewController
     self.window?.makeKeyAndVisible()
     
+    // Setting delegate for UNUserNotificationCenter
+    UNUserNotificationCenter.current().delegate = self
+
     // firebase used for app distribution.
     // FirebaseApp.configure(options: options)
     return true

--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -37,7 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     self.window?.rootViewController = rootViewController
     self.window?.makeKeyAndVisible()
     
-    // Setting delegate for UNUserNotificationCenter
+    // Set delegate for UNUserNotificationCenter
     UNUserNotificationCenter.current().delegate = self
 
     // firebase used for app distribution.


### PR DESCRIPTION
**Feel free to merge the PR when approved.**

Ami app is missing setting delegate for UNUserNotificationCenter that helps our SDK track user interaction.
